### PR TITLE
Fix kv editor

### DIFF
--- a/json-tree-editor/json-tree-editor-test.js
+++ b/json-tree-editor/json-tree-editor-test.js
@@ -415,18 +415,34 @@ describe("JSONTreeEditor", () => {
 		vm.hideKeyValueEditor(ev, "foo.bar");
 	});
 
-	it("makeSetKeyValueForPath", (done) => {
-		const vm = new ViewModel();
+	describe("makeSetKeyValueForPath", () => {
+		it("for string path", (done) => {
+			const vm = new ViewModel();
 
-		vm.listenTo("set-json-path-value", (ev, path, value) => {
-			assert.ok(true, "should dispatch set-json-path-value event");
-			assert.equal(path, "foo.bar", "should pass correct path+key");
-			assert.equal(value, "baz", "should pass correct value");
-			done();
+			vm.listenTo("set-json-path-value", (ev, path, value) => {
+				assert.ok(true, "should dispatch set-json-path-value event");
+				assert.equal(path, "foo.bar", "should pass correct path+key");
+				assert.equal(value, "baz", "should pass correct value");
+				done();
+			});
+
+			const setKeyValueForPath = vm.makeSetKeyValueForPath("foo");
+			setKeyValueForPath("bar", "baz");
 		});
 
-		const setKeyValueForPath = vm.makeSetKeyValueForPath("foo");
-		setKeyValueForPath("bar", "baz");
+		it("for empty path", (done) => {
+			const vm = new ViewModel();
+
+			vm.listenTo("set-json-path-value", (ev, path, value) => {
+				assert.ok(true, "should dispatch set-json-path-value event");
+				assert.equal(path, "bar", "should pass correct key");
+				assert.equal(value, "baz", "should pass correct value");
+				done();
+			});
+
+			const setKeyValueForPath = vm.makeSetKeyValueForPath("");
+			setKeyValueForPath("bar", "baz");
+		});
 	});
 
 	it("showOptions", (done) => {

--- a/json-tree-editor/json-tree-editor-test.js
+++ b/json-tree-editor/json-tree-editor-test.js
@@ -52,13 +52,13 @@ describe("JSONTreeEditor", () => {
 		vm.json = { arr: [] };
 
 		vm.dispatch("add-child", [ "arr" ]);
-		assert.deepEqual(vm.expandedKeys.serialize(), [ "arr.0" ], "dispatching an add-child event for a path containing an array expands the arrays first child");
+		assert.deepEqual(vm.expandedKeys.serialize(), [ "arr", "arr.0" ], "dispatching an add-child event for a path containing an array expands the array and its first child");
 
 		vm.dispatch("add-child", [ "arr" ]);
-		assert.deepEqual(vm.expandedKeys.serialize(), [ "arr.0" ], "dispatching a second add-child event for a path containing an array does nothing");
+		assert.deepEqual(vm.expandedKeys.serialize(), [ "arr", "arr.0" ], "dispatching a second add-child event for a path containing an array does nothing");
 
 		vm.dispatch("delete-json-path", [ "arr.0" ]);
-		assert.deepEqual(vm.expandedKeys.serialize(), [  ], "dispatching a delete-json-path event removes that path from expandedKeys");
+		assert.deepEqual(vm.expandedKeys.serialize(), [ "arr" ], "dispatching a delete-json-path event removes that path from expandedKeys");
 	});
 
 	it("json", () => {

--- a/json-tree-editor/json-tree-editor.js
+++ b/json-tree-editor/json-tree-editor.js
@@ -346,19 +346,21 @@ export const JSONTreeEditor = Component.extend({
 							{{# each(value) }}
 								{{> nodeTemplate }}
 							{{/ each }}
+
+							{{# if( scope.vm.shouldDisplayKeyValueEditor(path) ) }}
+								<div class="wrapper">
+									<div class="kv-group {{# if( isEven(value.length) ) }}even-row{{/ if }}">
+										<key-value-editor
+											setKeyValue:from="scope.vm.makeSetKeyValueForPath(path)"
+										></key-value-editor>
+										<div class="options">
+											<div on:click="scope.vm.hideKeyValueEditor(scope.event, path)">&minus;</div>
+										</div>
+									</div>
+								</div>
+							{{/ if }}
 						</div>
 					{{/ if }}
-				{{/ if }}
-
-				{{# if( scope.vm.shouldDisplayKeyValueEditor(path) ) }}
-					<div class="kv-group {{# if( isEven(value.length) ) }}even-row{{/ if }}">
-						<key-value-editor
-							setKeyValue:from="scope.vm.makeSetKeyValueForPath(path)"
-						></key-value-editor>
-						<div class="options">
-							<div on:click="scope.vm.hideKeyValueEditor(scope.event, path)">&minus;</div>
-						</div>
-					</div>
 				{{/ if }}
 			</div>
 		{{/ nodeTemplate }}	

--- a/json-tree-editor/json-tree-editor.js
+++ b/json-tree-editor/json-tree-editor.js
@@ -115,6 +115,10 @@ export const JSONTreeEditor = Component.extend({
 				});
 
 				listenTo("add-child", (ev, path) => {
+					if ( keys.indexOf(path) < 0 ) {
+						keys.push(path);
+					}
+
 					let parent = key.get(this.json, path);
 
 					if ( parent instanceof DefineList ) {

--- a/json-tree-editor/json-tree-editor.js
+++ b/json-tree-editor/json-tree-editor.js
@@ -74,6 +74,8 @@ export const JSONTreeEditor = Component.extend({
 	tag: "json-tree-editor",
 
 	ViewModel: {
+		rootNodeName: { type: "string", default: "JSON" },
+
 		displayedOptions: {
 			value({ listenTo, lastSet, resolve }) {
 				let options = resolve( new DefineList() );
@@ -271,7 +273,7 @@ export const JSONTreeEditor = Component.extend({
 
 		makeSetKeyValueForPath(path) {
 			return (key, value) => {
-				this.dispatch("set-json-path-value", [ path + "." + key, value ]);
+				this.dispatch("set-json-path-value", [ `${path ? path + "." : ""}` + key, value ]);
 			};
 		},
 
@@ -365,9 +367,36 @@ export const JSONTreeEditor = Component.extend({
 			</div>
 		{{/ nodeTemplate }}	
 
-		{{# each(parsedJSON) }}
-			{{> nodeTemplate }}
-		{{/ each }}
+		<div class="wrapper" on:mouseenter="scope.vm.showOptions(scope.event, '')" on:mouseleave="scope.vm.hideOptions(scope.event, '')">
+			<div class="header-container">
+				<div class="key">{{ rootNodeName }}</div>
+
+				{{# if( scope.vm.shouldShowOptions('') ) }}
+					<div class="options">
+						<div on:click="scope.vm.addChild(scope.event, '')">&plus;</div>
+					</div>
+				{{/ if }}
+			</div>
+
+			<div class="list-container">
+				{{# each(parsedJSON) }}
+					{{> nodeTemplate }}
+				{{/ each }}
+
+				{{# if( scope.vm.shouldDisplayKeyValueEditor('') ) }}
+					<div class="wrapper">
+						<div class="kv-group">
+							<key-value-editor
+								setKeyValue:from="scope.vm.makeSetKeyValueForPath('')"
+							></key-value-editor>
+							<div class="options">
+								<div on:click="scope.vm.hideKeyValueEditor(scope.event, '')">&minus;</div>
+							</div>
+						</div>
+					</div>
+				{{/ if }}
+			</div>
+		</div>
 	`
 });
 

--- a/json-tree-editor/json-tree-editor.js
+++ b/json-tree-editor/json-tree-editor.js
@@ -327,11 +327,11 @@ export const JSONTreeEditor = Component.extend({
 		{{< nodeTemplate }}
 			<div class="wrapper" on:click="scope.vm.toggleExpanded(scope.event, path)" on:mouseenter="scope.vm.showOptions(scope.event, path)" on:mouseleave="scope.vm.hideOptions(scope.event, path)">
 				{{# if( isList(value) ) }}
-					<div class="header-container">
+					<div class="header-container" on:click="scope.vm.toggleExpanded(scope.event, path)">
 						{{# if scope.vm.isExpanded(path) }}
-							<div class="arrow-toggle down" on:click="scope.vm.toggleExpanded(scope.event, path)"></div>
+							<div class="arrow-toggle {{# eq(arrowDirection, 'down') }}down{{/ eq }}" on:click="arrowDirection='right'"></div>
 						{{ else }}
-							<div class="arrow-toggle right" on:click="scope.vm.toggleExpanded(scope.event, path)"></div>
+							<div class="arrow-toggle {{# eq(arrowDirection, 'right') }}right{{/ eq }}" on:click="arrowDirection='down'"></div>
 						{{/ if }}
 
 						{{> keyValueTemplate }}
@@ -345,9 +345,10 @@ export const JSONTreeEditor = Component.extend({
 				{{# if( isList(value) ) }}
 					{{# if( scope.vm.isExpanded(path) ) }}
 						<div class="list-container">
-							{{# each(value) }}
-								{{> nodeTemplate }}
-							{{/ each }}
+							{{# for(child of value) }}
+								{{let arrowDirection=undefined}}
+								{{> nodeTemplate child }}
+							{{/ for }}
 
 							{{# if( scope.vm.shouldDisplayKeyValueEditor(path) ) }}
 								<div class="wrapper">
@@ -379,9 +380,10 @@ export const JSONTreeEditor = Component.extend({
 			</div>
 
 			<div class="list-container">
-				{{# each(parsedJSON) }}
-					{{> nodeTemplate }}
-				{{/ each }}
+				{{# for(node of parsedJSON) }}
+					{{let arrowDirection=undefined}}
+					{{> nodeTemplate node }}
+				{{/ for }}
 
 				{{# if( scope.vm.shouldDisplayKeyValueEditor('') ) }}
 					<div class="wrapper">

--- a/json-tree-editor/json-tree-editor.less
+++ b/json-tree-editor/json-tree-editor.less
@@ -43,8 +43,9 @@ json-tree-editor {
 			background-color: rgba(0, 0, 0, .025);
 			transition: background-color .2s ease-in-out;
 		}
-		> .key {
+		.key {
 			margin-left: @base-unit;
+			display: inline-block;
 		}
 	}
 	.arrow-toggle {
@@ -70,6 +71,7 @@ json-tree-editor {
 	}
 	.value {
 		color: @value-color;
+		display: inline-block;
 		&.string {
 			color: @string-color;
 			quotes: "“""”""‘""’";

--- a/viewmodel-editor/viewmodel-editor.js
+++ b/viewmodel-editor/viewmodel-editor.js
@@ -99,7 +99,7 @@ export default Component.extend({
 			{{/ unless }}
 		{{/ unless }}
 
-		<json-tree-editor json:from="json"></json-tree-editor>
+		<json-tree-editor json:from="json" rootNodeName:raw="ViewModel"></json-tree-editor>
 
 		{{# if(tagName) }}
 			<button on:click="this.save()">Save</button>


### PR DESCRIPTION
closes https://github.com/canjs/can-devtools-components/issues/25.

This also fixes a couple other issues
  - arrays automatically expand when adding a child
  - made it possible to add properties to ViewModel top level
  - made dropdown animations only happen on click (not on load)

![key-value-fixes](https://user-images.githubusercontent.com/5851984/47598953-cbdf4280-d969-11e8-9d6d-0af16e8971a9.gif)
