### PR TITLE
passing patches to updateValues instead of patched data

### DIFF
--- a/viewmodel-editor/viewmodel-editor-test.js
+++ b/viewmodel-editor/viewmodel-editor-test.js
@@ -53,11 +53,11 @@ describe("viewmodel-editor", () => {
 	describe("getPatchedData", () => {
 		let vm;
 
-		describe("add", () => {
-			beforeEach(() => {
-				vm = new ViewModel();
-			});
+		beforeEach(() => {
+			vm = new ViewModel();
+		});
 
+		describe("add", () => {
 			it("works", () => {
 				let destination = { aaa: "bbb", ccc: "ddd" };
 				let oldSource = {};
@@ -148,11 +148,15 @@ describe("viewmodel-editor", () => {
 	});
 
 	it("save", (done) => {
-		const patched = [ "one", "two" ];
+		const patches = [{
+			key: "foo", type: "set", value: "baz"
+		},{
+			index: 0, deleteCount: 1, insert: [], type: "splice", key: "list"
+		}];
 		const vm = new ViewModel({
-			patchedViewModelData: patched,
+			jsonEditorPatches: patches,
 			updateValues(p) {
-				assert.deepEqual(p, patched, "updateValues called with patchedViewModelData");
+				assert.deepEqual(p, patches, "updateValues called with jsonEditorPatches");
 			}
 		});
 

--- a/viewmodel-editor/viewmodel-editor.js
+++ b/viewmodel-editor/viewmodel-editor.js
@@ -89,23 +89,16 @@ export default Component.extend({
 			return patchedData;
 		},
 
-		get jsonEditorPatches() {
-			return diff.deep(this.serializedViewModelData, this.json.serialize());
-		},
-
-		patchedViewModelData: {
+		jsonEditorPatches: {
 			type: "any",
 			get(lastSet) {
 				if (lastSet) { return lastSet; }
-				const patches = this.jsonEditorPatches;
-				const patchedViewModelData = this.getPatchedData(this.serializedViewModelData, patches);
-
-				return patchedViewModelData;
+				return diff.deep(this.serializedViewModelData, this.json.serialize());
 			}
 		},
 
 		save() {
-			this.updateValues( this.patchedViewModelData );
+			this.updateValues( this.jsonEditorPatches );
 			this.dispatch("reset-json-patches");
 		},
 


### PR DESCRIPTION
This fixes an issue when not all items in a list have been serialized.
This allows the injected-script to patch the viewmodel directly, instead
of trying to assignDeep the data as constructed by the viewmodel-editor.