### PR TITLE
fixing indentation of nested properties in json-editor

### DIFF
--- a/json-tree-editor/json-tree-editor.less
+++ b/json-tree-editor/json-tree-editor.less
@@ -27,6 +27,11 @@ json-tree-editor {
 		div:first-child {
 			margin-right: @half-unit;
 		}
+
+		turning-arrow {
+			position: absolute;
+			left: -20px;
+		}
 	}
 	.list-container {
 		display: flex;


### PR DESCRIPTION
closes https://github.com/canjs/can-devtools-components/issues/78.

![image](https://user-images.githubusercontent.com/5851984/52151420-acc31180-2638-11e9-89ed-62ecddc49035.png)
