### PR TITLE
 handling deselecting selectedNode when it is replaced

### DIFF
--- a/component-tree/component-tree-test.js
+++ b/component-tree/component-tree-test.js
@@ -85,5 +85,24 @@ describe("component-tree", () => {
 
 		vm.componentTree.updateDeep([]);
 		assert.equal(vm.selectedNode, undefined, "selectedNode is cleared if tree is cleared");
+
+		vm.componentTree.updateDeep([{
+			selected: false,
+			tagName: "todo-list",
+			id: 0,
+			children: []
+		}]);
+
+		vm.selectedNode = vm.componentTree[0];
+		assert.equal(vm.selectedNode, vm.componentTree[0], "selectedNode set to only node");
+
+		vm.componentTree.updateDeep([{
+			selected: false,
+			tagName: "other-list",
+			id: 1,
+			children: []
+		}]);
+
+		assert.equal(vm.selectedNode, undefined, "selectedNode is cleared if only node is replaced");
 	});
 });

--- a/component-tree/component-tree.js
+++ b/component-tree/component-tree.js
@@ -1,4 +1,4 @@
-import { Component, DefineList, DefineMap, stache, value } from "can";
+import { Component, DefineList, DefineMap, stache, value, Reflect } from "can";
 
 import "component-tree/component-tree.less";
 
@@ -30,22 +30,34 @@ export default Component.extend({
 				let selectedNode = resolve(lastSet.get());
 
 				listenTo(lastSet, (node) => {
+					// tear down old listeners
+					if (selectedNode) {
+						Reflect.offKeyValue(selectedNode, "id");
+					}
+
 					selectedNode = resolve(node);
+
+					if (selectedNode) {
+						// if node is replaced by a node with a different id, deselect it
+						Reflect.onKeyValue(selectedNode, "id", () => {
+							selectedNode = resolve(undefined);
+						});
+					}
 				});
 
 				// recursively find a node in a tree that has `selected: true`
 				const findNode = (list, filterFn) => {
-					let selectedNode;
+					let foundNode;
 
 					list.some((node) => {
 						if (filterFn(node)) {
-							selectedNode = node;
+							foundNode = node;
 							return true;
 						}
-						selectedNode = findNode(node.children, filterFn);
+						foundNode = findNode(node.children, filterFn);
 					});
 
-					return selectedNode;
+					return foundNode;
 				};
 
 				// create an observable that represents the `selected: true` node
@@ -102,4 +114,4 @@ export default Component.extend({
 	`
 });
 
-export { Component, DefineList, DefineMap, stache };
+export { Component, DefineList, DefineMap, stache, value, Reflect };


### PR DESCRIPTION
closes https://github.com/canjs/devtools/issues/68.

![replace-selected-node](https://user-images.githubusercontent.com/5851984/52253750-4146a180-28cf-11e9-816b-7a1084e80845.gif)
