### PR TITLE
handling another case where selectedNode needs to be cleared

### DIFF
--- a/component-tree/component-tree-test.js
+++ b/component-tree/component-tree-test.js
@@ -89,7 +89,7 @@ describe("component-tree", () => {
 		vm.componentTree.updateDeep([{
 			selected: false,
 			tagName: "todo-list",
-			id: 0,
+			id: 6,
 			children: []
 		}]);
 
@@ -99,10 +99,58 @@ describe("component-tree", () => {
 		vm.componentTree.updateDeep([{
 			selected: false,
 			tagName: "other-list",
-			id: 1,
+			id: 7,
 			children: []
 		}]);
 
 		assert.equal(vm.selectedNode, undefined, "selectedNode is cleared if only node is replaced");
+
+		vm.componentTree.updateDeep([{
+			selected: false,
+			tagName: "todo-list",
+			id: 8,
+			children: [{
+				selected: true,
+				tagName: "todo-item",
+				id: 9,
+				children: []
+			},{
+				selected: false,
+				tagName: "todo-editor",
+				id: 10,
+				children: []
+			},{
+				selected: false,
+				tagName: "todo-item",
+				id: 11,
+				children: []
+			}]
+		}]);
+
+		assert.equal(vm.selectedNode, vm.componentTree[0].children[0], "selectedNode set again to node with `selected: true`");
+
+		vm.componentTree.updateDeep([{
+			selected: false,
+			tagName: "todo-list",
+			id: 8,
+			children: [{
+				selected: false,
+				tagName: "todo-item",
+				id: 12,
+				children: []
+			},{
+				selected: false,
+				tagName: "todo-editor",
+				id: 10,
+				children: []
+			},{
+				selected: false,
+				tagName: "todo-item",
+				id: 11,
+				children: []
+			}]
+		}]);
+
+		assert.equal(vm.selectedNode, undefined, "selectedNode is cleared if selectedNode is replaced");
 	});
 });


### PR DESCRIPTION
This handles when a node is selected in the tree (`selected: true`) and
is then replaced by another node. In this case, selectedNode is now
cleared.

Another fix for https://github.com/canjs/devtools/issues/68.

![replace-selected-node](https://user-images.githubusercontent.com/5851984/52285350-c790d100-292b-11e9-831d-32415aa65cc6.gif)
