### PR TITLE
not resetting selectedNode if ID changes but its still selected

### DIFF
--- a/component-tree/component-tree-test.js
+++ b/component-tree/component-tree-test.js
@@ -152,5 +152,23 @@ describe("component-tree", () => {
 		}]);
 
 		assert.equal(vm.selectedNode, undefined, "selectedNode is cleared if selectedNode is replaced");
+
+		vm.componentTree.updateDeep([{
+			selected: true,
+			tagName: "todo-list",
+			id: 13,
+			children: []
+		}]);
+
+		assert.equal(vm.selectedNode, vm.componentTree[0], "selectedNode set to only node again");
+
+		vm.componentTree.updateDeep([{
+			selected: true,
+			tagName: "other-list",
+			id: 14,
+			children: []
+		}]);
+
+		assert.equal(vm.selectedNode, vm.componentTree[0], "selectedNode not reset if its ID changes");
 	});
 });

--- a/component-tree/component-tree.js
+++ b/component-tree/component-tree.js
@@ -32,9 +32,13 @@ export default Component.extend({
 			value({ listenTo, lastSet, resolve }) {
 				let selectedNode = resolve(lastSet.get());
 
-				// if node is replaced by a node with a different id, deselect it
+				// if node is replaced by a node with a different id,
+				// deselect it unless the node is still selected
 				const resetOnIdChange = () => {
 					if (selectedNode) {
+						if (selectedNode.selected) {
+							return;
+						}
 						Reflect.offKeyValue(selectedNode, "id", resetOnIdChange);
 					}
 					selectedNode = resolve(undefined);


### PR DESCRIPTION
closes https://github.com/canjs/can-devtools-components/issues/84.

![selected-node-fix](https://user-images.githubusercontent.com/5851984/52387183-cb694400-2a4e-11e9-9bd3-2faeb1a37fab.gif)
