### PR TITLE
Fix the view-model editor height cut off

### DIFF
--- a/expandable-section/expandable-section-test.js
+++ b/expandable-section/expandable-section-test.js
@@ -37,17 +37,4 @@ describe("expandable-section", () => {
 
 		assert.equal(vm.collapsible, true, "collapsible === true");
 	});
-
-	it('sectionHeight', () => {
-		var expandableComponent = new Component();
-		var viewModel = expandableComponent.viewModel;
-		assert.equal(viewModel.sectionHeight, viewModel.sectionEl.clientHeight, "got section height from the section div");
-	});
-
-	it('sectionTitleHeight', () => {
-		var expandableComponent = new Component();
-		var viewModel = expandableComponent.viewModel;
-		assert.equal(viewModel.sectionTitleHeight, viewModel.sectionTitle.clientHeight, "got section title height");
-	});
-
 });

--- a/expandable-section/expandable-section-test.js
+++ b/expandable-section/expandable-section-test.js
@@ -38,4 +38,16 @@ describe("expandable-section", () => {
 		assert.equal(vm.collapsible, true, "collapsible === true");
 	});
 
+	it('sectionHeight', () => {
+		var expandableComponent = new Component();
+		var viewModel = expandableComponent.viewModel;
+		assert.equal(viewModel.sectionHeight, viewModel.sectionEl.clientHeight, "got section height from the section div");
+	});
+
+	it('sectionTitleHeight', () => {
+		var expandableComponent = new Component();
+		var viewModel = expandableComponent.viewModel;
+		assert.equal(viewModel.sectionTitleHeight, viewModel.sectionTitle.clientHeight, "got section title height");
+	});
+
 });

--- a/expandable-section/expandable-section.js
+++ b/expandable-section/expandable-section.js
@@ -11,6 +11,37 @@ export default Component.extend({
 		height: { type: "number", default: 300 },
 		title: { type: "string", default: "Expandable Section" },
 		collapsible: { type: "boolean", default: true },
+		/**
+		 * The section element
+		 */
+		sectionEl: {
+			type: "any"
+		},
+		/**
+		 * Section header
+		 */
+		sectionTitle: {
+			type: "any"
+		},
+		/**
+		 * the actual section height (height property is for max-height)
+		 */
+		sectionHeight: {
+			value({lastSet, listenTo, resolve}) {
+				resolve(lastSet.get());
+				listenTo("sectionEl", (ev, el) => {
+					resolve(el.clientHeight);
+				});
+			}
+		},
+		sectionTitleHeight: {
+			value({lastSet, listenTo, resolve}) {
+				resolve(lastSet.get());
+				listenTo("sectionTitle", (ev, el) => {
+					resolve(el.clientHeight);
+				});
+			}
+		},
 		expanded: {
 			default: false,
 			value({ lastSet, listenTo, resolve }) {
@@ -36,8 +67,8 @@ export default Component.extend({
 	},
 
 	view: `
-		<div class="{{# if(collapsible) }}collapsible{{/ if }}" on:click="expanded = not(expanded)" {{# if(expanded) }}style="max-height: {{height}}px"{{/ if }}>
-			<div class="title">
+		<div this:to="sectionEl" class="{{# if(collapsible) }}collapsible{{/ if }}" on:click="expanded = not(expanded)" {{# if(expanded) }}style="max-height: {{height}}px"{{/ if }}>
+			<div this:to="sectionTitle" class="title">
 				{{# if(collapsible) }}
 					<turning-arrow down:bind="expanded" />
 				{{/ if }}

--- a/expandable-section/expandable-section.js
+++ b/expandable-section/expandable-section.js
@@ -26,22 +26,18 @@ export default Component.extend({
 		/**
 		 * the actual section height (height property is for max-height)
 		 */
-		sectionHeight: {
-			value({lastSet, listenTo, resolve}) {
-				resolve(lastSet.get());
-				listenTo("sectionEl", (ev, el) => {
-					resolve(el.clientHeight);
-				});
+		get sectionHeight() {
+			if (this.sectionEl) {
+ 				return this.sectionEl.clientHeight;
 			}
-		},
-		sectionTitleHeight: {
-			value({lastSet, listenTo, resolve}) {
-				resolve(lastSet.get());
-				listenTo("sectionTitle", (ev, el) => {
-					resolve(el.clientHeight);
-				});
+			return 0;
+ 		},
+ 		get sectionTitleHeight() {
+			if (this.sectionTitle) {
+				return this.sectionTitle.clientHeight;
 			}
-		},
+			return 0;
+ 		},
 		expanded: {
 			default: false,
 			value({ lastSet, listenTo, resolve }) {

--- a/expandable-section/expandable-section.js
+++ b/expandable-section/expandable-section.js
@@ -14,30 +14,11 @@ export default Component.extend({
 		/**
 		 * The section element
 		 */
-		sectionEl: {
-			type: "any"
-		},
+		sectionEl: "any",
 		/**
 		 * Section header
 		 */
-		sectionTitle: {
-			type: "any"
-		},
-		/**
-		 * the actual section height (height property is for max-height)
-		 */
-		get sectionHeight() {
-			if (this.sectionEl) {
- 				return this.sectionEl.clientHeight;
-			}
-			return 0;
- 		},
- 		get sectionTitleHeight() {
-			if (this.sectionTitle) {
-				return this.sectionTitle.clientHeight;
-			}
-			return 0;
- 		},
+		sectionTitle: "any",
 		expanded: {
 			default: false,
 			value({ lastSet, listenTo, resolve }) {
@@ -63,14 +44,14 @@ export default Component.extend({
 	},
 
 	view: `
-		<div this:to="sectionEl" class="{{# if(collapsible) }}collapsible{{/ if }}" on:click="expanded = not(expanded)" {{# if(expanded) }}style="max-height: {{height}}px"{{/ if }}>
+		<div class="{{# if(collapsible) }}collapsible{{/ if }}" on:click="expanded = not(expanded)" {{# if(expanded) }}style="max-height: {{height}}px"{{/ if }}>
 			<div this:to="sectionTitle" class="title">
 				{{# if(collapsible) }}
 					<turning-arrow down:bind="expanded" />
 				{{/ if }}
 				<p {{# not(collapsible) }}class="not-collapsible"{{/ not }}>{{title}}</p>
 			</div>
-			<div class="content-container {{# if(expanded) }}expanded{{/ if }}" on:click="scope.event.stopPropagation()">
+			<div this:to="sectionEl" class="content-container {{# if(expanded) }}expanded{{/ if }}" on:click="scope.event.stopPropagation()">
 				<content/>
 			</div>
 		</div>

--- a/expandable-section/expandable-section.js
+++ b/expandable-section/expandable-section.js
@@ -11,14 +11,8 @@ export default Component.extend({
 		height: { type: "number", default: 300 },
 		title: { type: "string", default: "Expandable Section" },
 		collapsible: { type: "boolean", default: true },
-		/**
-		 * The section element
-		 */
-		sectionEl: "any",
-		/**
-		 * Section header
-		 */
 		sectionTitle: "any",
+		
 		expanded: {
 			default: false,
 			value({ lastSet, listenTo, resolve }) {
@@ -40,18 +34,18 @@ export default Component.extend({
 					}
 				});
 			}
-		},
+		}
 	},
 
 	view: `
-		<div class="{{# if(collapsible) }}collapsible{{/ if }}" on:click="expanded = not(expanded)" {{# if(expanded) }}style="max-height: {{height}}px"{{/ if }}>
+		<div class="{{# if(collapsible) }}collapsible{{/ if }}" on:click="expanded = not(expanded)">
 			<div this:to="sectionTitle" class="title">
 				{{# if(collapsible) }}
 					<turning-arrow down:bind="expanded" />
 				{{/ if }}
 				<p {{# not(collapsible) }}class="not-collapsible"{{/ not }}>{{title}}</p>
 			</div>
-			<div this:to="sectionEl" class="content-container {{# if(expanded) }}expanded{{/ if }}" on:click="scope.event.stopPropagation()">
+			<div class="content-container {{# if(expanded) }}expanded{{/ if }}" on:click="scope.event.stopPropagation()" style="height: {{height}}px">
 				<content/>
 			</div>
 		</div>

--- a/panel/panel-test.js
+++ b/panel/panel-test.js
@@ -11,16 +11,4 @@ describe("components-panel", () => {
 		const vm = new ViewModel();
 		assert.ok(vm);
 	});
-
-	it("breakpointsCurrentHeight", () => {
-		const viewModel = new ViewModel();
-		viewModel.breakpointsSection = { clientHeight: 100 };
-		assert.equal(viewModel.breakpointsCurrentHeight, 100, "Got the current height of the breakpoints section");
-	});
-
-	it("breakpointsTitleHeight", () => {
-		const viewModel = new ViewModel();
-		viewModel.breakpointsTitle = { clientHeight: 30 };
-		assert.equal(viewModel.breakpointsTitleHeight, 30, "Got the height of the breakpoints section title");
-	});
 });

--- a/panel/panel-test.js
+++ b/panel/panel-test.js
@@ -1,4 +1,5 @@
 import Component from "./panel";
+
 import "steal-mocha";
 import chai from "chai";
 
@@ -9,5 +10,17 @@ describe("components-panel", () => {
 	it("basics", () => {
 		const vm = new ViewModel();
 		assert.ok(vm);
+	});
+
+	it("breakpointsCurrentHeight", () => {
+		const viewModel = new ViewModel();
+		viewModel.breakpointsSection = { clientHeight: 100 };
+		assert.equal(viewModel.breakpointsCurrentHeight, 100, "Got the current height of the breakpoints section");
+	});
+
+	it("breakpointsTitleHeight", () => {
+		const viewModel = new ViewModel();
+		viewModel.breakpointsTitle = { clientHeight: 30 };
+		assert.equal(viewModel.breakpointsTitleHeight, 30, "Got the height of the breakpoints section title");
 	});
 });

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -13,6 +13,8 @@ export default Component.extend({
 		connectedCallback(el) {
 			const setHeight = () => {
 				this.scrollableAreaHeight = el.clientHeight;
+				this.breakpointsTitleHeight = this.breakpointsTitle.clientHeight;
+				this.viewModelTitleHeight = this.viewModelTitle.clientHeight;
 			};
 
 			// set default height
@@ -20,7 +22,7 @@ export default Component.extend({
 
 			// set height when page is resized
 			window.addEventListener("resize", setHeight);
-
+			
 			return () => {
 				window.removeEventListener("resize", setHeight);
 			};
@@ -28,17 +30,12 @@ export default Component.extend({
 		scrollableAreaHeight: { type: "number", default: 400 },
 		get viewModelEditorHeight() {
 			if (this.breakpointsExpanded) {
-				if (this.breakpoints.length === 0) {
-					return this.scrollableAreaHeight - this.breakpointsCurrentHeight;
-				} else {
-					return Math.ceil(2 * this.scrollableAreaHeight / 3);
-				}
+				return (this.scrollableAreaHeight - this.breakpointsHeight) - (this.breakpointsTitleHeight + this.viewModelTitleHeight);
 			}
-			// remove the title height in order to prevent scroll over breakpoint section
-			return this.scrollableAreaHeight - this.breakpointsTitleHeight;
+			return this.scrollableAreaHeight - (this.breakpointsTitleHeight + this.viewModelTitleHeight);
 		},
 		get breakpointsHeight() {
-			return Math.floor((1 * this.scrollableAreaHeight) / 3);
+			return Math.floor((1 * this.scrollableAreaHeight) / 3)  - this.breakpointsTitleHeight;
 		},
 
 		// component tree fields
@@ -61,19 +58,9 @@ export default Component.extend({
 		//breakpoints DOM fields
 		breakpointsExpanded: "boolean",
 		breakpointsTitle: "any",
-		breakpointsSection: "any",
-		get breakpointsCurrentHeight() {
-			if (this.breakpointsSection) {
-				return this.breakpointsSection.clientHeight;
-			}
-			return 0;
-		},
-		get breakpointsTitleHeight() {
-			if (this.breakpointsTitle) {
-				return this.breakpointsTitle.clientHeight;
-			}
-			return 0;
-		},
+		viewModelTitle: "any",
+		breakpointsTitleHeight: "number",
+		viewModelTitleHeight: "number",
 
 		// viewmodel editor functions
 		updateValues: {
@@ -115,23 +102,25 @@ export default Component.extend({
 					></component-tree>
 				</div>
 			</div>
-			<div class="sidebar">
-				<expandable-section title:raw="ViewModel Mutation Breakpoints" 
-									height:bind="breakpointsHeight" 
-									sectionTitle:to="breakpointsTitle" 
-									sectionEl:to="breakpointsSection"
-									expanded:to="breakpointsExpanded"
-				>
-					<breakpoints-editor
-						breakpoints:bind="breakpoints"
-						addBreakpoint:from="addBreakpoint"
-						toggleBreakpoint:from="toggleBreakpoint"
-						deleteBreakpoint:from="deleteBreakpoint"
-						error:bind="breakpointsError"
-					></breakpoints-editor>
-				</expandable-section>
+			<div class="sidebar" style="height: {{scrollableAreaHeight}}px">
+					
+					<expandable-section title:raw="ViewModel Mutation Breakpoints" sectionTitle:to="breakpointsTitle" height:from="breakpointsHeight"
+										expanded:bind="breakpointsExpanded"
+					>
+						<breakpoints-editor
+							breakpoints:bind="breakpoints"
+							addBreakpoint:from="addBreakpoint"
+							toggleBreakpoint:from="toggleBreakpoint"
+							deleteBreakpoint:from="deleteBreakpoint"
+							error:bind="breakpointsError"
+						></breakpoints-editor>
+					</expandable-section>
+					
 
-				<expandable-section title:raw="ViewModel Editor" expanded:from="true" height:bind="viewModelEditorHeight">
+					
+					<expandable-section title:raw="ViewModel Editor" expanded:from="true" sectionTitle:to="viewModelTitle"
+										height:from="viewModelEditorHeight"
+					>
 					<viewmodel-editor
 						tagName:from="this.selectedNode.tagName"
 						viewModelData:bind="viewModelData"
@@ -142,7 +131,9 @@ export default Component.extend({
 						expandedKeys:to="expandedKeys"
 						error:bind="viewModelEditorError"
 					></viewmodel-editor>
-				</expandable-section>
+						
+					</expandable-section>
+					
 			</div>
 		</div>
 	`

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -28,11 +28,14 @@ export default Component.extend({
 		scrollableAreaHeight: { type: "number", default: 400 },
 		get viewModelEditorHeight() {
 			if (this.breakpointsExpanded) {
-				// Increase the height of the view-model editor by the actual breakpoint section height
-				return Math.ceil(2 * this.scrollableAreaHeight / 3) + this.breakpointsCurrentHeight;
+				if (this.breakpoints.length === 0) {
+					return this.scrollableAreaHeight - this.breakpointsCurrentHeight;
+				} else {
+					return Math.ceil(2 * this.scrollableAreaHeight / 3);
+				}
 			}
 			// remove the title height in order to prevent scroll over breakpoint section
-			return this.scrollableAreaHeight - this.breakpointsTitleHeight || 0 ;
+			return this.scrollableAreaHeight - this.breakpointsTitleHeight;
 		},
 		get breakpointsHeight() {
 			return Math.floor((1 * this.scrollableAreaHeight) / 3);
@@ -57,8 +60,20 @@ export default Component.extend({
 
 		//breakpoints DOM fields
 		breakpointsExpanded: "boolean",
-		breakpointsCurrentHeight: "number",
-		breakpointsTitleHeight: "number",
+		breakpointsTitle: "any",
+		breakpointsSection: "any",
+		get breakpointsCurrentHeight() {
+			if (this.breakpointsSection) {
+				return this.breakpointsSection.clientHeight;
+			}
+			return 0;
+		},
+		get breakpointsTitleHeight() {
+			if (this.breakpointsTitle) {
+				return this.breakpointsTitle.clientHeight;
+			}
+			return 0;
+		},
 
 		// viewmodel editor functions
 		updateValues: {
@@ -103,8 +118,9 @@ export default Component.extend({
 			<div class="sidebar">
 				<expandable-section title:raw="ViewModel Mutation Breakpoints" 
 									height:bind="breakpointsHeight" 
-									sectionTitleHeight:to="breakpointsTitleHeight" 
-									sectionHeight:to="breakpointsCurrentHeight"
+									sectionTitle:to="breakpointsTitle" 
+									sectionEl:to="breakpointsSection"
+									expanded:to="breakpointsExpanded"
 				>
 					<breakpoints-editor
 						breakpoints:bind="breakpoints"

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -32,7 +32,7 @@ export default Component.extend({
 				return Math.ceil(2 * this.scrollableAreaHeight / 3) + this.breakpointsCurrentHeight;
 			}
 			// remove the title height in order to prevent scroll over breakpoint section
-			return this.scrollableAreaHeight - this.viewModelEditorTitleHeight || 0 ;
+			return this.scrollableAreaHeight - this.breakpointsTitleHeight || 0 ;
 		},
 		get breakpointsHeight() {
 			return Math.floor((1 * this.scrollableAreaHeight) / 3);

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -22,7 +22,7 @@ export default Component.extend({
 
 			// set height when page is resized
 			window.addEventListener("resize", setHeight);
-			
+
 			return () => {
 				window.removeEventListener("resize", setHeight);
 			};
@@ -54,9 +54,9 @@ export default Component.extend({
 		// breakpoints fields
 		breakpoints: DefineList,
 		breakpointsError: "string",
+		breakpointsExpanded: "boolean",
 
 		//breakpoints DOM fields
-		breakpointsExpanded: "boolean",
 		breakpointsTitle: "any",
 		viewModelTitle: "any",
 		breakpointsTitleHeight: "number",
@@ -103,24 +103,27 @@ export default Component.extend({
 				</div>
 			</div>
 			<div class="sidebar" style="height: {{scrollableAreaHeight}}px">
-					
-					<expandable-section title:raw="ViewModel Mutation Breakpoints" sectionTitle:to="breakpointsTitle" height:from="breakpointsHeight"
-										expanded:bind="breakpointsExpanded"
-					>
-						<breakpoints-editor
-							breakpoints:bind="breakpoints"
-							addBreakpoint:from="addBreakpoint"
-							toggleBreakpoint:from="toggleBreakpoint"
-							deleteBreakpoint:from="deleteBreakpoint"
-							error:bind="breakpointsError"
-						></breakpoints-editor>
-					</expandable-section>
-					
+				<expandable-section 
+					title:raw="ViewModel Mutation Breakpoints" 
+					sectionTitle:to="breakpointsTitle" 
+					height:from="breakpointsHeight"
+					expanded:bind="breakpointsExpanded"
+				>
+					<breakpoints-editor
+						breakpoints:bind="breakpoints"
+						addBreakpoint:from="addBreakpoint"
+						toggleBreakpoint:from="toggleBreakpoint"
+						deleteBreakpoint:from="deleteBreakpoint"
+						error:bind="breakpointsError"
+					></breakpoints-editor>
+				</expandable-section>
 
-					
-					<expandable-section title:raw="ViewModel Editor" expanded:from="true" sectionTitle:to="viewModelTitle"
-										height:from="viewModelEditorHeight"
-					>
+				<expandable-section 
+					title:raw="ViewModel Editor" 
+					expanded:from="true"
+					sectionTitle:to="viewModelTitle"
+					height:from="viewModelEditorHeight"
+				>
 					<viewmodel-editor
 						tagName:from="this.selectedNode.tagName"
 						viewModelData:bind="viewModelData"
@@ -131,9 +134,7 @@ export default Component.extend({
 						expandedKeys:to="expandedKeys"
 						error:bind="viewModelEditorError"
 					></viewmodel-editor>
-						
-					</expandable-section>
-					
+				</expandable-section>
 			</div>
 		</div>
 	`

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -27,7 +27,12 @@ export default Component.extend({
 		},
 		scrollableAreaHeight: { type: "number", default: 400 },
 		get viewModelEditorHeight() {
-			return Math.ceil((2 * this.scrollableAreaHeight) / 3);
+			if (this.breakpointsExpanded) {
+				// Increase the height of the view-model editor by the actual breakpoint section height
+				return Math.ceil(2 * this.scrollableAreaHeight / 3) + this.breakpointsCurrentHeight;
+			}
+			// remove the title height in order to prevent scroll over breakpoint section
+			return this.scrollableAreaHeight - this.viewModelEditorTitleHeight || 0 ;
 		},
 		get breakpointsHeight() {
 			return Math.floor((1 * this.scrollableAreaHeight) / 3);
@@ -50,11 +55,17 @@ export default Component.extend({
 		breakpoints: DefineList,
 		breakpointsError: "string",
 
+		//breakpoints DOM fields
+		breakpointsExpanded: "boolean",
+		breakpointsCurrentHeight: "number",
+		breakpointsTitleHeight: "number",
+
 		// viewmodel editor functions
 		updateValues: {
 			default: () =>
 				(data) => console.log("updating viewModel with", data)
 		},
+		
 
 		// breakpoints functions
 		addBreakpoint: {
@@ -90,7 +101,11 @@ export default Component.extend({
 				</div>
 			</div>
 			<div class="sidebar">
-				<expandable-section title:raw="ViewModel Mutation Breakpoints" height:bind="breakpointsHeight">
+				<expandable-section title:raw="ViewModel Mutation Breakpoints" 
+									height:bind="breakpointsHeight" 
+									sectionTitleHeight:to="breakpointsTitleHeight" 
+									sectionHeight:to="breakpointsCurrentHeight"
+				>
 					<breakpoints-editor
 						breakpoints:bind="breakpoints"
 						addBreakpoint:from="addBreakpoint"

--- a/panel/panel.less
+++ b/panel/panel.less
@@ -3,6 +3,7 @@
 components-panel {
 	display: block;
 	height: 100%;
+	overflow: hidden;
 
 	.grid-container {
 		display: grid;
@@ -49,7 +50,7 @@ components-panel {
 			grid-area: sidebar;
 			line-height: 1.5;
 			border-left: 1px solid #d0d0d0;
-
+			//overflow-y: hidden;
 
 			.viewmodel-editor {
 				> h2 {

--- a/panel/panel.less
+++ b/panel/panel.less
@@ -3,7 +3,7 @@
 components-panel {
 	display: block;
 	height: 100%;
-	overflow: hidden;
+	overflow-y: hidden;
 
 	.grid-container {
 		display: grid;

--- a/panel/panel.less
+++ b/panel/panel.less
@@ -50,7 +50,6 @@ components-panel {
 			grid-area: sidebar;
 			line-height: 1.5;
 			border-left: 1px solid #d0d0d0;
-			//overflow-y: hidden;
 
 			.viewmodel-editor {
 				> h2 {


### PR DESCRIPTION
Fixes #86 

The logic behind the fix is to calculate the height of the view-model editor in two cases:

_**1. When the breakpoints section is expanded**_: The real/actual occupied height (not the max-height) by the breakpoints editor is be added to the view-model height in order to keep it visible in the two thirds of the available height space.

_**2. When the breakpoints section is not expanded**_: Here the view-model editor will have the height of the available space but without the height of breakpoints section in order to prevent scrolling outside the view-model editor.

I added properties to bound `expanded-section` component height and the height of the collapsible title with `components-panel` component.