### PR TITLE
Get steal-tools build working

### DIFF
--- a/build.js
+++ b/build.js
@@ -9,7 +9,8 @@ stealTools.export({
 		main: "can-devtools-components"
 	},
 	options: {
-		verbose: true
+		verbose: true,
+		sourceMaps: false
 	},
 	outputs: {
 		"components": {


### PR DESCRIPTION
There is a [known bug in steal-tools](https://github.com/stealjs/steal-tools/issues/1144) preventing apps using some ES2015
features to build (like template literals) when ES5 transpilation is
turned off. Disabling sourceMaps generation is a workaround until the
issue is fixed.

Closes #96 