### PR TITLE
Add a reset button when viewmodel-editor has unapplied changes

### DIFF
--- a/viewmodel-editor/viewmodel-editor-test.js
+++ b/viewmodel-editor/viewmodel-editor-test.js
@@ -87,12 +87,12 @@ describe("viewmodel-editor", () => {
 			"`undefined` properties that are set don't reset to `undefined`"
 		);
 
-		vm.dispatch("reset-json-patches");
+		vm.jsonEditorPatches = [];
 		vm.viewModelData = { abc: "hij", def: "nop", ghi: ["rst"] };
 		assert.deepEqual(
 			vm.json.serialize(),
 			{ abc: "hij", def: "nop", ghi: ["rst"] },
-			"updates when viewModelData is updated again after reset-json-patches event"
+			"updates when viewModelData is updated again after patches are reset"
 		);
 
 		vm.assign({
@@ -245,62 +245,45 @@ describe("viewmodel-editor", () => {
 					patches,
 					"updateValues called with jsonEditorPatches"
 				);
+				done();
 			}
-		});
-
-		vm.listenTo("reset-json-patches", () => {
-			assert.ok(true, "reset-json-patches event dispatched");
-			done();
 		});
 
 		vm.save();
 	});
 
-	it("reset", done => {
-		let asserts = 3;
+	it("reset", () => {
 		const patches = [
 			{
 				key: "foo",
 				type: "set",
 				value: "baz"
-			},
-			{
-				index: 0,
-				deleteCount: 1,
-				insert: [],
-				type: "splice",
-				key: "list"
 			}
 		];
 		const vm = new ViewModelEditor().initialize({
-			jsonEditorPatches: patches,
 			updateValues() {
 				assert.ok(
 					false,
 					"updateValues called (should not be)"
 				);
-				done();
 			},
 			viewModelData: {
 				abc: "xyz",
 				def: "uvw",
-				ghi: []
+				ghi: [],
+				foo: null
 			}
 		});
-		const json = vm.json;
+		const json = vm.json.serialize();
+		vm.json.foo = "baz"; // sets patches
 
-		vm.listenTo("reset-json-patches", () => {
-			assert.ok(true, "reset-json-patches event dispatched");
-			asserts -= 1;
-			asserts || done();
-		});
-		vm.listenTo("serializedViewModelData", (ev, vmJson) => {
-			assert.ok(true, "serializedViewModelData event dispatched");
-			assert.deepEqual(vmJson, json);
-			asserts -= 2;
-			asserts || done();
-		});
+		assert.deepEqual(vm.getPatchedData(json, vm.jsonEditorPatches), vm.json.serialize(), "json patches");
+		assert.deepEqual(vm.jsonEditorPatches, patches, "json patches");
 
 		vm.reset();
+
+		assert.deepEqual(vm.json, json);
+		assert.deepEqual(vm.jsonEditorPatches, []);
+
 	});
 });

--- a/viewmodel-editor/viewmodel-editor-test.js
+++ b/viewmodel-editor/viewmodel-editor-test.js
@@ -255,4 +255,52 @@ describe("viewmodel-editor", () => {
 
 		vm.save();
 	});
+
+	it("reset", done => {
+		let asserts = 3;
+		const patches = [
+			{
+				key: "foo",
+				type: "set",
+				value: "baz"
+			},
+			{
+				index: 0,
+				deleteCount: 1,
+				insert: [],
+				type: "splice",
+				key: "list"
+			}
+		];
+		const vm = new ViewModelEditor().initialize({
+			jsonEditorPatches: patches,
+			updateValues() {
+				assert.ok(
+					false,
+					"updateValues called (should not be)"
+				);
+				done();
+			},
+			viewModelData: {
+				abc: "xyz",
+				def: "uvw",
+				ghi: []
+			}
+		});
+		const json = vm.json;
+
+		vm.listenTo("reset-json-patches", () => {
+			assert.ok(true, "reset-json-patches event dispatched");
+			asserts -= 1;
+			asserts || done();
+		});
+		vm.listenTo("serializedViewModelData", (ev, vmJson) => {
+			assert.ok(true, "serializedViewModelData event dispatched");
+			assert.deepEqual(vmJson, json);
+			asserts -= 2;
+			asserts || done();
+		});
+
+		vm.reset();
+	});
 });

--- a/viewmodel-editor/viewmodel-editor.js
+++ b/viewmodel-editor/viewmodel-editor.js
@@ -40,11 +40,14 @@ export default class ViewmodelEditor extends StacheElement {
 					{{ else }}
 						<h1>{{ this.tagName }} ViewModel</h1>
 
-						{{# if(this.jsonEditorPatches.length) }}
-							<button on:click="this.save()">Apply Changes</button>
-						{{ else }}
-							<button class="disabled">Up To Date</button>
-						{{/ if }}
+						<span class="buttons">
+							{{# if(this.jsonEditorPatches.length) }}
+								<button on:click="this.save()">Apply</button>
+								<button on:click="this.reset()">Reset</button>
+							{{ else }}
+								<button class="disabled">Up To Date</button>
+							{{/ if }}
+						</span>
 					{{/ unless }}
 				{{/ unless }}
 			</div>
@@ -211,6 +214,11 @@ export default class ViewmodelEditor extends StacheElement {
 	save() {
 		this.updateValues(this.jsonEditorPatches);
 		this.dispatch("reset-json-patches");
+	}
+
+	reset() {
+		this.dispatch("reset-json-patches");
+		this.dispatch("serializedViewModelData", [this.viewModelData]);
 	}
 
 	static get propertyDefaults() {

--- a/viewmodel-editor/viewmodel-editor.less
+++ b/viewmodel-editor/viewmodel-editor.less
@@ -11,5 +11,11 @@ viewmodel-editor {
 			font-size: @font-lg;
 			font-style: italic;
 		}
+		.buttons {
+			margin-left: auto;
+			button {
+				margin: 0;
+			}
+		}
 	}
 }


### PR DESCRIPTION
 The Reset button reverts unapplied changes to the viewmodel editor fields, and shows fields' values matching what is on the source object.

"Apply Changes" has been shortened to "Apply" to make room for the Reset button.

![image](https://user-images.githubusercontent.com/18686722/68700317-b5932d00-0552-11ea-8667-2726c91a5ecb.png)
