### PR TITLE
Convert viewModelData to a DeepObservable to update the viemodel editor properly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     }
   },
   "dependencies": {
-    "can": "^6.2.1"
+    "can": "^6.2.7"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -59,7 +59,7 @@ export default class ComponentsPanel extends StacheElement {
 					>
 						<can-template name="contentTemplate">
 							<viewmodel-editor
-								tagName:from="this.selectedNode.tagName"
+								tagName:from="this.tagName"
 								viewModelData:bind="this.viewModelData"
 								typeNamesData:bind="this.typeNamesData"
 								messages:bind="this.messages"
@@ -105,6 +105,10 @@ export default class ComponentsPanel extends StacheElement {
 
 			selectedNode: type.maybeConvert(ObservableObject),
 			componentTreeError: String,
+			tagName: {
+				type: String,
+				get default() { return ""; }
+			},
 
 			// viewmodel editor fields
 			viewModelData: DeepObservable,

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -1,4 +1,5 @@
 import {
+	DeepObservable,
 	ObservableArray,
 	ObservableObject,
 	Reflect,
@@ -106,7 +107,7 @@ export default class ComponentsPanel extends StacheElement {
 			componentTreeError: String,
 
 			// viewmodel editor fields
-			viewModelData: type.convert(ObservableObject),
+			viewModelData: DeepObservable,
 
 			typeNamesData: type.convert(ObservableObject),
 			messages: type.convert(ObservableObject),
@@ -176,4 +177,4 @@ export default class ComponentsPanel extends StacheElement {
 
 customElements.define("components-panel", ComponentsPanel);
 
-export { StacheElement, ObservableObject, ObservableArray, Reflect, type };
+export { StacheElement, DeepObservable, ObservableObject, ObservableArray, Reflect, type };

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -105,10 +105,7 @@ export default class ComponentsPanel extends StacheElement {
 
 			selectedNode: type.maybeConvert(ObservableObject),
 			componentTreeError: String,
-			tagName: {
-				type: String,
-				get default() { return ""; }
-			},
+			tagName: "",
 
 			// viewmodel editor fields
 			viewModelData: DeepObservable,

--- a/viewmodel-editor/viewmodel-editor-test.js
+++ b/viewmodel-editor/viewmodel-editor-test.js
@@ -95,6 +95,13 @@ describe("viewmodel-editor", () => {
 			"updates when viewModelData is updated again after patches are reset"
 		);
 
+		vm.jsonEditorPatches = [{ type: "set", key: "abc", value: "klm" }];
+		assert.deepEqual(
+			vm.json.serialize(),
+			{ abc: "klm", def: "nop", ghi: ["rst"] },
+			"updates when patches are set"
+		);
+
 		vm.assign({
 			tagName: "foo",
 			viewModelData: {}

--- a/viewmodel-editor/viewmodel-editor-test.js
+++ b/viewmodel-editor/viewmodel-editor-test.js
@@ -310,6 +310,7 @@ describe("viewmodel-editor", () => {
 				foo: null
 			}
 		});
+		vm.listenTo("jsonEditorPatches", noop);
 		const json = vm.json.serialize();
 		vm.json.foo = "baz"; // sets patches
 

--- a/viewmodel-editor/viewmodel-editor-test.js
+++ b/viewmodel-editor/viewmodel-editor-test.js
@@ -95,7 +95,9 @@ describe("viewmodel-editor", () => {
 			"updates when viewModelData is updated again after patches are reset"
 		);
 
-		vm.jsonEditorPatches = [{ type: "set", key: "abc", value: "klm" }];
+		vm.jsonEditorPatches = [
+			{ type: "set", key: "abc", value: "klm" }
+		];
 		assert.deepEqual(
 			vm.json.serialize(),
 			{ abc: "klm", def: "nop", ghi: ["rst"] },
@@ -108,6 +110,33 @@ describe("viewmodel-editor", () => {
 		});
 		assert.deepEqual(vm.json.serialize(), {}, "resets when tagName changes");
 	});
+
+	it("jsonEditorPatches", () => {
+		const vm = new ViewModelEditor().initialize({
+			viewModelData: {
+				abc: "xyz",
+				def: "uvw",
+				ghi: []
+			},
+			tagName: "tagName"
+		});
+		vm.listenTo("jsonEditorPatches", noop);
+
+		assert.deepEqual(vm.jsonEditorPatches.get(), [], "patches are initially empty");
+
+		const patch = { type: "set", key: "abc", value: "jkl" };
+		vm.jsonEditorPatches.push(patch);
+		assert.deepEqual(vm.jsonEditorPatches.get(), [patch], "patches are settable");
+
+		vm.tagName = "differentTagName";
+		assert.deepEqual(vm.jsonEditorPatches.get(), [], "patches are empty after tagName change");
+
+		vm.jsonEditorPatches.push(patch);
+		vm.viewModelData = {
+			abc: "mnopq"
+		};
+		assert.deepEqual(vm.json.get(), { abc: "jkl" }, "patches are unchanged by change in vm data");
+	})
 
 	describe("getPatchedData", () => {
 		let vm;

--- a/viewmodel-editor/viewmodel-editor.js
+++ b/viewmodel-editor/viewmodel-editor.js
@@ -66,7 +66,7 @@ export default class ViewmodelEditor extends StacheElement {
 
 	static get props() {
 		return {
-			tagName: { type: type.convert(String), default: "" },
+			tagName: "",
 
 			viewModelData: {
 				type: DeepObservable,
@@ -174,16 +174,16 @@ export default class ViewmodelEditor extends StacheElement {
 			jsonEditorPatches: {
 				type: type.convert(ObservableArray),
 				value({ lastSet, listenTo, resolve }) {
-					listenTo(lastSet, resolve);
+					let patches = resolve(lastSet.get() || new ObservableArray([]));
+
+					listenTo(lastSet, value => {
+						patches = resolve(value)
+					});
 
 					listenTo("tagName", () => {
-						lastSet.get().updateDeep([]);
+						patches.updateDeep([]);
 					});
-					resolve(lastSet.get());
 				},
-				get default() {
-					return new ObservableArray([]);
-				}
 			},
 
 			updateValues: {

--- a/viewmodel-editor/viewmodel-editor.js
+++ b/viewmodel-editor/viewmodel-editor.js
@@ -167,15 +167,22 @@ export default class ViewmodelEditor extends StacheElement {
 						Reflect.offValue(serializedJSON, setPatches);
 						json.updateDeep({});
 						Reflect.onValue(serializedJSON, setPatches);
-						this.jsonEditorPatches.splice(0, this.jsonEditorPatches.length);
 					});
 				}
 			},
 
 			jsonEditorPatches: {
-				type: type.ObservableArray,
+				type: type.convert(ObservableArray),
+				value({ lastSet, listenTo, resolve }) {
+					listenTo(lastSet, resolve);
+
+					listenTo("tagName", () => {
+						lastSet.get().updateDeep([]);
+					});
+					resolve(lastSet.get());
+				},
 				get default() {
-					return []
+					return new ObservableArray([]);
 				}
 			},
 

--- a/viewmodel-editor/viewmodel-editor.js
+++ b/viewmodel-editor/viewmodel-editor.js
@@ -165,9 +165,9 @@ export default class ViewmodelEditor extends StacheElement {
 
 					listenTo("tagName", () => {
 						Reflect.offValue(serializedJSON, setPatches);
-						json.update({});
+						json.updateDeep({});
 						Reflect.onValue(serializedJSON, setPatches);
-						this.jsonEditorPatches = [];
+						this.jsonEditorPatches.splice(0, this.jsonEditorPatches.length);
 					});
 				}
 			},
@@ -229,6 +229,7 @@ export default class ViewmodelEditor extends StacheElement {
 customElements.define("viewmodel-editor", ViewmodelEditor);
 
 export {
+	DeepObservable,
 	StacheElement,
 	ObservableObject,
 	ObservableArray,

--- a/viewmodel-editor/viewmodel-editor.js
+++ b/viewmodel-editor/viewmodel-editor.js
@@ -69,10 +69,10 @@ export default class ViewmodelEditor extends StacheElement {
 			tagName: { type: type.convert(String), default: "" },
 
 			viewModelData: {
-				type: type.convert(ObservableObject),
+				type: DeepObservable,
 
 				get default() {
-					return new ObservableObject();
+					return Reflect.new(DeepObservable, {});
 				}
 			},
 


### PR DESCRIPTION
DeepObservable fires changes when deep properties change on it, which in this case makes the `json` property in the viewmodel editor update its properties -- this wasn't happening correctly with ObservableObject.