### PR TITLE
Update set-value listener in bindings graph to not remove live-bound text nodes

### DIFF
--- a/editable-span/editable-span-test.js
+++ b/editable-span/editable-span-test.js
@@ -10,7 +10,7 @@ describe("editable-span", () => {
 	describe("ViewModel", () => {
 		it("edit() / save()", () => {
 			const el = new EditableSpan();
-			el.initialize();
+			el.connect(); // start listeners and ensure the span child is available
 
 			el.listenTo("editing", () => {});
 			el.listenTo("text", () => {});
@@ -18,8 +18,6 @@ describe("editable-span", () => {
 			el.edit(ev);
 
 			assert.ok(el.editing, "edit() sets editing to true");
-			el.connect(); // start listeners
-			el.render(); // ensure the span child is available
 			el.querySelector("span").appendChild(document.createElement("br"));  // this happens often when the user hits enter.
 
 			el.save("foo");

--- a/editable-span/editable-span-test.js
+++ b/editable-span/editable-span-test.js
@@ -18,10 +18,15 @@ describe("editable-span", () => {
 			el.edit(ev);
 
 			assert.ok(el.editing, "edit() sets editing to true");
+			el.connect(); // start listeners
+			el.render(); // ensure the span child is available
+			el.querySelector("span").appendChild(document.createElement("br"));  // this happens often when the user hits enter.
 
 			el.save("foo");
+
 			assert.notOk(el.editing, "save() sets editing to false");
 			assert.equal(el.text, "foo", "save() sets text");
+			assert.equal(el.querySelector("span").children.length, 0, "save() removes line breaks.");
 		});
 
 		it("showOptions", () => {

--- a/editable-span/editable-span.js
+++ b/editable-span/editable-span.js
@@ -25,7 +25,8 @@ export default class EditableSpan extends StacheElement {
 				class="{{# if(this.editing) }}editing{{/ if }} {{# if(this.wrapInQuotes) }}quotes{{/ if }}"
 				{{# if(this.editing) }}contenteditable="true"{{/ if }}
 				tabindex="0"
-			>{{ this.text }}</span>
+				innerText:from="this.text"
+			></span>
 
 			{{# if(this.showOptions) }}
 				<ul>
@@ -100,8 +101,8 @@ export default class EditableSpan extends StacheElement {
 			}
 		});
 
-		this.listenTo("set-value", (ev, val) => {
-			span.innerText = val;
+		this.listenTo("set-value", () => {
+			[].forEach.call(span.children, child => span.removeChild(child));
 		});
 
 		this.listenTo(this, "focus", () => {

--- a/panel/panel.html
+++ b/panel/panel.html
@@ -21,6 +21,8 @@
 
 		<script src="../node_modules/steal/steal.js">
 					import {
+				ObservableArray,
+				ObservableObject,
 				Reflect,
 				StacheElement,
 				type
@@ -90,6 +92,11 @@
 						},
 
 						todos: {
+							type: type.convert(class extends ObservableArray {
+								static get items() {
+									return type.convert(ObservableObject);
+								}
+							}),
 							get default() {
 								return [
 									{
@@ -200,6 +207,7 @@
 						}
 					});
 
+					panel.tagName = (sourceVm.tagName || "").toLowerCase();
 					Reflect.updateDeep(panel.viewModelData, sourceVm);
 				}
 			};
@@ -210,6 +218,7 @@
 				selectedNode = node;
 				const el = elsById[node.id];
 				sourceVm = el;
+				panel.tagName = (sourceVm.tagName || "").toLowerCase();
 				Reflect.updateDeep(panel.viewModelData, sourceVm);
 			});
 


### PR DESCRIPTION
The editable-span component had an event listener which directly updated the DOM. In CanJS 6, this can break live binding, since text nodes are responsible for updating themselves.  In this case since we just want text content, any element children (which are not the live-bound text node) are removed.

* Includes changing span content to use `innerText:from` which avoids some weirdness with the contentEditable properties.
* Also includes fixes to panel.html demo page