### PR TITLE
Make styles readable in dark mode

### DIFF
--- a/expandable-section/expandable-section.less
+++ b/expandable-section/expandable-section.less
@@ -16,7 +16,9 @@ expandable-section {
 			padding: @sm-unit @third-unit;
 			border-bottom: 1px solid #d0d0d0;
 			flex-shrink: 0; // needed for scrollbar
-
+			@media (prefers-color-scheme: dark) {
+				border-bottom-color: #3D3D3D;
+			}
 			p {
 				margin: 0;
 				padding: 0;
@@ -28,18 +30,29 @@ expandable-section {
 			}
 		}
 
+		&.collapsible {
+			@media (prefers-color-scheme: dark) {
+				background-color: #333333;
+			}
+		}
+
 		&.collapsible:hover {
 			background-color: #E0E0E0;
+			@media (prefers-color-scheme: dark) {
+				background-color: #000;
+			}
 		}
 
 		.content-container {
 			display: none;
 			padding: @sm-unit;
-
 			&.expanded {
 				display: flex;
 				flex-direction: column;
 				background: #FFFFFF;
+				@media (prefers-color-scheme: dark) {
+					background-color: #242424;
+				}
 				border-top: none;
 				overflow-y: auto; // needed for scrollbar
 				flex-grow: 1; // needed for scrollbar

--- a/panel/panel.less
+++ b/panel/panel.less
@@ -31,6 +31,10 @@ components-panel {
 				align-items: center;
 				background-color: #f3f3f3;
 				border-bottom: 1px solid #d0d0d0;
+				@media (prefers-color-scheme: dark) {
+					background-color: #333333;
+					border-bottom: none;
+				}
 				padding: @sm-unit @third-unit;
 				flex-shrink: 0; // needed for scrollbar
 				h1 {
@@ -50,7 +54,9 @@ components-panel {
 			grid-area: sidebar;
 			line-height: 1.5;
 			border-left: 1px solid #d0d0d0;
-
+			@media (prefers-color-scheme: dark) {
+				border-left-color: #3D3D3D;
+			}
 			.viewmodel-editor {
 				> h2 {
 					text-align: left;

--- a/styles.less
+++ b/styles.less
@@ -40,6 +40,9 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+    @media (prefers-color-scheme: dark) {
+        color: #ADADAD;
+    }
 }
 body {
 	font-family: 'Noto Sans JP', sans-serif;

--- a/turning-arrow/turning-arrow.less
+++ b/turning-arrow/turning-arrow.less
@@ -16,7 +16,9 @@ turning-arrow {
 		border-left: (@arrow-border + 2) solid @base-color;
 		transform-origin: center center;
 		vertical-align: middle;
-
+		@media (prefers-color-scheme: dark) {
+			border-left-color: #ADADAD;
+		}
 		&.right {
 			transform: rotate(0deg);
 			&.animate {


### PR DESCRIPTION
Fixes https://github.com/canjs/devtools/issues/83

<img width="1440" alt="Screen Shot 2019-12-19 at 8 20 13 PM" src="https://user-images.githubusercontent.com/109013/71202893-50430200-229d-11ea-84b0-f26e2594c274.png">
<img width="694" alt="Screen Shot 2019-12-19 at 8 20 24 PM" src="https://user-images.githubusercontent.com/109013/71202894-50430200-229d-11ea-9809-aa3c299baa79.png">
<img width="696" alt="Screen Shot 2019-12-19 at 8 20 37 PM" src="https://user-images.githubusercontent.com/109013/71202895-50db9880-229d-11ea-90a6-a22411d5fe40.png">
